### PR TITLE
Path based deployment of GeoServer in Tomcat

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ docker run -e USE_WPS=1 -e USE_VECTOR_TILES=1 -p 18080:8080 meggsimum/geoserver:
 
 you'll get a GeoServer with installed and activated WPS and Vector Tiles extension.
 
+## Change Deployment Path
+
+This Docker Image allows to deploy GeoServer under a given path instead of always being hosted under /geoserver.
+
+The path is defined in the environment variable `APP_PATH_PREFIX` in
+the form `foo#bar#`, which leads the application being
+hosted under `/foo/bar/geoserver/`. If the env var is not set the
+GeoServer will be hosted under `/geoserver` as usual.
+
+By running
+
+```shell
+docker run -e APP_PATH_PREFIX="foo#bar#" -p 18080:8080 meggsimum/geoserver:2.16.2
+```
+
+you'll get the GeoServer deployed at http://localhost:18080/foo/bar/geoserver/.
+
 ## Build this Image
 
 ```shell
@@ -63,4 +80,4 @@ docker build -t {YOUR_TAG} .
 ## Credits
 This GeoServer Docker Image was heavily inspired by the one here: https://github.com/terrestris/docker-geoserver/ of the [terrestris](https://github.com/terrestris) organization. Thank you!
 
-Also a big thank you to the fabulous [GeoServer project](http://geoserver.org) and its maintainers / contributors. GeoServer is excellent, you rock!  
+Also a big thank you to the fabulous [GeoServer project](http://geoserver.org) and its maintainers / contributors. GeoServer is excellent, you rock!

--- a/startup.sh
+++ b/startup.sh
@@ -8,35 +8,43 @@ VT_PLUGIN_PATH=$EXTENSIONS_PATH"vectortiles"
 WPS_PLUGIN_PATH=$EXTENSIONS_PATH"wps"
 IMG_MOSAIC_PLUGIN_PATH=$EXTENSIONS_PATH"imagemosaic-jdbc"
 
+# adapt deployment path
+if [[ $APP_PATH_PREFIX ]]; then  # var is set and it is not empty
+   echo "Using app path prefix " $APP_PATH_PREFIX
+   # move GeoServer installation to get a different deployment path
+   # e.g. foo#bar#geoserver.war leads to /foo/bar/geoserver/
+   mv $CATALINA_HOME/webapps/geoserver/ $CATALINA_HOME/webapps/$APP_PATH_PREFIX"geoserver/"
+fi
+
 # VECTOR TILES
 if [ "$USE_VECTOR_TILES" == 1 ]; then
   echo "Copy Vector Tiles extension to our GeoServer lib directory";
   ls -la $VT_PLUGIN_PATH
-  cp $VT_PLUGIN_PATH/*.jar $CATALINA_HOME/webapps/geoserver/WEB-INF/lib/
+  cp $VT_PLUGIN_PATH/*.jar $CATALINA_HOME/webapps/$APP_PATH_PREFIX"geoserver/WEB-INF/lib/"
 fi
 # WPS
 if [ "$USE_WPS" == 1 ]; then
   echo "Copy WPS extension to our GeoServer lib directory";
   ls -la $WPS_PLUGIN_PATH
-  cp $WPS_PLUGIN_PATH/*.jar $CATALINA_HOME/webapps/geoserver/WEB-INF/lib/
+  cp $WPS_PLUGIN_PATH/*.jar $CATALINA_HOME/webapps/$APP_PATH_PREFIX"geoserver/WEB-INF/lib/"
 fi
 # IMAGE MOSAIC JDBC
 if [ "$USE_IMG_MOSAIC" == 1 ]; then
   echo "Copy Imagemosaic JDBC extension to our GeoServer lib directory";
   ls -la $IMG_MOSAIC_PLUGIN_PATH
-  cp $IMG_MOSAIC_PLUGIN_PATH/*.jar $CATALINA_HOME/webapps/geoserver/WEB-INF/lib/
+  cp $IMG_MOSAIC_PLUGIN_PATH/*.jar $CATALINA_HOME/webapps/$APP_PATH_PREFIX"geoserver/WEB-INF/lib/"
 fi
 
 # copy additional geoserver libs before starting the tomcat
 if [ -d "$ADDITIONAL_LIBS_DIR" ]; then
-    cp $ADDITIONAL_LIBS_DIR/*.jar $CATALINA_HOME/webapps/geoserver/WEB-INF/lib/
+    cp $ADDITIONAL_LIBS_DIR/*.jar $CATALINA_HOME/webapps/$APP_PATH_PREFIX"geoserver/WEB-INF/lib/"
 fi
 
 # ENABLE CORS
 if [ "$USE_CORS" == 1 ]; then
   echo "Enabling CORS for GeoServer"
   echo "Copy a modified web.xml to $CATALINA_HOME/geoserver/WEB-INF/";
-  cp /opt/web-cors-enabled.xml $CATALINA_HOME/webapps/geoserver/WEB-INF/web.xml
+  cp /opt/web-cors-enabled.xml $CATALINA_HOME/webapps/$APP_PATH_PREFIX"geoserver/WEB-INF/web.xml"
 fi
 
 # start the tomcat


### PR DESCRIPTION
This ensures that the GeoServer application is hosted under a given path, instead of always being hosted under `/geoserver`.

The path is defined in the environment variable `APP_PATH_PREFIX` in the form` foo#bar#`, which leads the application being
hosted under `/foo/bar/geoserver/`. If the env var is not set the GeoServer will be hosted under `/geoserver` as usual.