### PR TITLE
Remove injection of patched ("norce") log4j jar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ ENV EXTRA_JAVA_OPTS="-Xms256m -Xmx1g"
 ENV USE_VECTOR_TILES=0
 ENV USE_WPS=0
 ENV USE_CORS=0
-ENV USE_NORCE_LOG4J_JAR=1
 
 # see http://docs.geoserver.org/stable/en/user/production/container.html
 ENV CATALINA_OPTS="\$EXTRA_JAVA_OPTS -Dfile.encoding=UTF-8 -D-XX:SoftRefLRUPolicyMSPerMB=36000 -Xbootclasspath/a:$CATALINA_HOME/lib/marlin.jar -Xbootclasspath/p:$CATALINA_HOME/lib/marlin-sun-java2d.jar -Dsun.java2d.renderer=org.marlin.pisces.PiscesRenderingEngine -Dorg.geotools.coverage.jaiext.enabled=true"

--- a/startup.sh
+++ b/startup.sh
@@ -34,15 +34,6 @@ if [ -d "$ADDITIONAL_LIBS_DIR" ]; then
     cp $ADDITIONAL_LIBS_DIR/*.jar $CATALINA_HOME/webapps/$APP_PATH_PREFIX"geoserver/WEB-INF/lib/"
 fi
 
-# No RCE Log4J Jar (see http://geoserver.org/announcements/2021/12/13/logj4-rce-statement.html)
-if [ "$USE_NORCE_LOG4J_JAR" == 1 ]; then
-  echo "Using the patched norce log4j 1.2.17 jar";
-  # remove malicious log4j-1.2.17.jar
-  rm $CATALINA_HOME/webapps/$APP_PATH_PREFIX"geoserver/WEB-INF/lib/log4j-1.2.17.jar"
-  # download and install patched log4j jar file into lib folder
-  wget --no-check-certificate -P $CATALINA_HOME/webapps/$APP_PATH_PREFIX"geoserver/WEB-INF/lib/" https://repo.osgeo.org/repository/geotools-releases/log4j/log4j/1.2.17.norce/log4j-1.2.17.norce.jar
-fi
-
 # ENABLE CORS
 if [ "$USE_CORS" == 1 ]; then
   echo "Enabling CORS for GeoServer"


### PR DESCRIPTION
The patch for log4j v1 issues is integrated in the official releases since GeoServer 2.19.4 / 2.20.2. Therefore this removes the hotfix by downloading the patched jar introduced in #5.