### PR TITLE
Add `UPDATE_CREDENTIALS` to prevent update credentials on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ENV EXTRA_JAVA_OPTS="-Xms256m -Xmx1g"
 ENV USE_VECTOR_TILES=0
 ENV USE_WPS=0
 ENV USE_CORS=0
+ENV UPDATE_CREDENTIALS=1
 
 # see http://docs.geoserver.org/stable/en/user/production/container.html
 ENV CATALINA_OPTS="\$EXTRA_JAVA_OPTS -Dfile.encoding=UTF-8 -D-XX:SoftRefLRUPolicyMSPerMB=36000 -Xbootclasspath/a:$CATALINA_HOME/lib/marlin.jar -Xbootclasspath/p:$CATALINA_HOME/lib/marlin-sun-java2d.jar -Dsun.java2d.renderer=org.marlin.pisces.PiscesRenderingEngine -Dorg.geotools.coverage.jaiext.enabled=true"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ you'll get a cleaned standard GeoServer (Version 2.19.3), which can be accessed 
   - `USE_WPS=1` (0/1)
   - `USE_VECTOR_TILES=1` (0/1)
   - `APP_PATH_PREFIX="my#deploy#path#"` (any string compliant to [Tomcat context path naming](https://tomcat.apache.org/tomcat-8.0-doc/config/context.html) )
+  - `UPDATE_CREDENTIALS` (0/1) If the credentials shall be updated on startup (Default is `0`)
   - `GEOSERVER_ADMIN_USER` (String - supported since 2.19.x)
   - `GEOSERVER_ADMIN_PASSWORD` (String - supported since 2.19.x)
 
@@ -85,6 +86,12 @@ In order to have individual admin credentials in your running container the envi
 
 ```shell
 docker run -e GEOSERVER_ADMIN_USER=peter -e GEOSERVER_ADMIN_PASSWORD=abcd -p 18080:8080 meggsimum/geoserver:2.19.3
+```
+
+Setting `UPDATE_CREDENTIALS` to `0` does not update the credentials on startup. This is useful if an existing volume shall be mounted that already has credentials set up.
+
+```shell
+docker run -e UPDATE_CREDENTIALS=0 -v $(pwd)/geoserver_data:/opt/geoserver_data -p 8080:8080 meggsimum/geoserver:latest
 ```
 
 ## Build this Image

--- a/startup.sh
+++ b/startup.sh
@@ -42,7 +42,9 @@ if [ "$USE_CORS" == 1 ]; then
 fi
 
 # set credentials
-/bin/sh /opt/update_credentials.sh
+if [ "$UPDATE_CREDENTIALS" == 1 ]; then
+  /bin/sh /opt/update_credentials.sh
+fi
 
 # start the tomcat
 $CATALINA_HOME/bin/catalina.sh run


### PR DESCRIPTION
- adds environment variable `UPDATE_CREDENTIALS`. Default is `1` and keeps current behavior
- setting to `1` skips the script `update_credentials.sh` and therefore prevents any update of credentials on startup
- this is useful if an existing volume with changed credentials shall be mounted