### PR TITLE
Migrate Tomcat image, minor Upgrade, fix failing GDAL installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN apk -U upgrade --update && \
     --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
     --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
     --repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
+    --allow-untrusted \
     gdal
 
 # clenaup webapps

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM openjdk:8-jdk-alpine
 
 # Environment variables
 ENV TOMCAT_MAJOR=8 \
-    TOMCAT_VERSION=8.5.37 \
+    TOMCAT_VERSION=8.5.81 \
     CATALINA_HOME=/opt/tomcat
 
 # init

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,32 @@
-# Use a tomcat image of terrestris as parent
-FROM terrestris/tomcat:8.5.37
+FROM openjdk:8-jdk-alpine
+
+# Install Tomcat
+# inspired by https://github.com/terrestris/docker-tomcat/blob/master/Dockerfile
+
+# Environment variables
+ENV TOMCAT_MAJOR=8 \
+    TOMCAT_VERSION=8.5.37 \
+    CATALINA_HOME=/opt/tomcat
+
+# init
+RUN apk -U upgrade --update && \
+    apk add curl && \
+    apk add ttf-dejavu
+
+RUN mkdir -p /opt
+
+# install tomcat
+RUN curl -jkSL -o /tmp/apache-tomcat.tar.gz http://archive.apache.org/dist/tomcat/tomcat-${TOMCAT_MAJOR}/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz && \
+    gunzip /tmp/apache-tomcat.tar.gz && \
+    tar -C /opt -xf /tmp/apache-tomcat.tar && \
+    ln -s /opt/apache-tomcat-$TOMCAT_VERSION $CATALINA_HOME
+
+# cleanup
+RUN rm -rf /tmp/* /var/cache/apk/*
+
+EXPOSE 8080
+
+# Install GeoServer
 
 # The GS_VERSION argument could be used like this to overwrite the default:
 # docker build --build-arg GS_VERSION=2.17.3 -t meggsimum/geoserver:2.17.3 .


### PR DESCRIPTION
- [Upgrade Tomcat from '8.5.37' to '8.5.81'](https://github.com/meggsimum/geoserver-docker/commit/4542d013439f340944202c21e2fb36893b65a44c)
- [Integrate tomcat image directly in GeoServer image](https://github.com/meggsimum/geoserver-docker/commit/2ea49d853670a3f263d5cc0886aabda96cffd77c)
- [Add "allow-untrusted" to GDAL installation](https://github.com/meggsimum/geoserver-docker/commit/50e879baa1c5de0560bf57723c44dce177531dba)