### PR TITLE
Upgrade to version  `v2.21.1`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ EXPOSE 8080
 
 # The GS_VERSION argument could be used like this to overwrite the default:
 # docker build --build-arg GS_VERSION=2.17.3 -t meggsimum/geoserver:2.17.3 .
-ARG GS_VERSION=2.21.0
+ARG GS_VERSION=2.21.1
 ARG GS_DATA_PATH=./geoserver_data/
 ARG ADDITIONAL_LIBS_PATH=./additional_libs/
 


### PR DESCRIPTION
 `v2.21.1` has been released. See https://geoserver.org/announcements/2022/08/01/geoserver-2-21-1-released.html