### PR TITLE
Upgrade GeoServer to `2.21.2`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ EXPOSE 8080
 
 # The GS_VERSION argument could be used like this to overwrite the default:
 # docker build --build-arg GS_VERSION=2.17.3 -t meggsimum/geoserver:2.17.3 .
-ARG GS_VERSION=2.21.1
+ARG GS_VERSION=2.21.2
 ARG GS_DATA_PATH=./geoserver_data/
 ARG ADDITIONAL_LIBS_PATH=./additional_libs/
 


### PR DESCRIPTION
- updates GeoServer to `2.21.2`
- the local build ran fine
- I could start the web UI 
- I ran the test suite from `geoserver-node-client` and all tests passed