### PR TITLE
Upgrade to `2.22.2`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ EXPOSE 8080
 
 # The GS_VERSION argument could be used like this to overwrite the default:
 # docker build --build-arg GS_VERSION=2.17.3 -t meggsimum/geoserver:2.17.3 .
-ARG GS_VERSION=2.22.1
+ARG GS_VERSION=2.22.2
 ARG GS_DATA_PATH=./geoserver_data/
 ARG ADDITIONAL_LIBS_PATH=./additional_libs/
 


### PR DESCRIPTION
- Upgrade to `2.22.2`
- see GeoServer release https://github.com/geoserver/geoserver/releases/tag/2.22.2
- basic tests like opening UI and sending some REST requests worked locally